### PR TITLE
Fix wrapper memory leak

### DIFF
--- a/csrc/miniomodule/miniomodule.c
+++ b/csrc/miniomodule/miniomodule.c
@@ -158,7 +158,17 @@ PyCache_read(PyCache *self, PyObject *args, PyObject *kwds)
         return NULL;
     }
 
-    return PyTuple_Pack(2, PyBytes_FromStringAndSize((char *) self->temp, size), PyLong_FromLong(size));
+    PyObject *bytes = PyBytes_FromStringAndSize((char *) self->temp, size);
+    PyObject *size_ = PyLong_FromLong(size);
+    PyObject *out = PyTuple_Pack(2, bytes, size_);
+
+    /* Because PyTuple_Pack increments the reference counter for all inputs,
+       we must decrement the refcounts to prevent a leak where the count is >1
+       when we return. */
+    Py_DECREF(bytes);
+    Py_DECREF(size_);
+
+    return out;
 }
 
 /* PyCache method to flush the cache. */

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup, Extension
 
 MAJOR = 0
 MINOR = 2
-MICRO = 1
+MICRO = 2
 VERSION = '{}.{}.{}'.format(MAJOR, MINOR, MICRO)
 
 with open('README.md', 'r') as f:


### PR DESCRIPTION
Wrapper was making a call to `PyTuple_Pack` on `file_read`, which increased the refcount of the arguments to the function. This resulted in the refcount being 2 when we returned, causing the image data and accompanying long to never be GCed.