### PR TITLE
Use shm to allocate memory for file data

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,7 @@ This module adds a new class, `minio.PyCache`, initialized with parameters `size
 
 ### `PyCache.contains(filepath: str)`
 
-Returns `True` if `filepath` has an entry in the cache, otherwise returns
-`False`.
+Returns `True` if `filepath` has an entry in the cache, otherwise returns `False`.
 
 ### `PyCache.store(filepath: str, bytes: int, data: bytearray)`
 
@@ -40,14 +39,11 @@ Stores `bytes` bytes of data from `data` in the cache, indexed by `filepath`.
 
 ### `PyCache.load(filepath: str)`
 
-Load the data at `filepath` from the cache, returning a tuple `(data, size)`,
-where `data` is the bytes read, and `size` is the number of bytes. On miss, does
-not issue any IO, instead returning `None`.
+Load the data at `filepath` from the cache, returning a tuple `(data, size)`, where `data` is the bytes read, and `size` is the number of bytes. On miss, does not issue any IO, instead returning `None`.
 
 ### `PyCache.read_file(filepath: str)`
 
-Reads the file at `filepath` through the cache, returning a tuple `(data, size)`,
-where `data` is the bytes read, and `size` is the number of bytes.
+Reads the file at `filepath` through the cache, returning a tuple `(data, size)`, where `data` is the bytes read, and `size` is the number of bytes.
 
 ### `PyCache.flush()`
 

--- a/csrc/minio/minio.c
+++ b/csrc/minio/minio.c
@@ -1,25 +1,25 @@
 /* MIT License
 
-   Copyright (c) 2023 Gus Waldspurger
+    Copyright (c) 2023 Gus Waldspurger
 
-   Permission is hereby granted, free of charge, to any person obtaining a copy
-   of this software and associated documentation files (the "Software"), to deal
-   in the Software without restriction, including without limitation the rights
-   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-   copies of the Software, and to permit persons to whom the Software is
-   furnished to do so, subject to the following conditions:
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
 
-   The above copyright notice and this permission notice shall be included in all
-   copies or substantial portions of the Software.
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
 
-   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-   SOFTWARE.
-   */
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+    */
 
 #define _GNU_SOURCE
 
@@ -49,217 +49,222 @@
 bool
 cache_contains(cache_t *cache, char *path)
 {
-   hash_entry_t *entry = NULL;
-   HASH_FIND_STR(cache->ht, path, entry);
+    hash_entry_t *entry = NULL;
+    HASH_FIND_STR(cache->ht, path, entry);
 
-   return (entry != NULL);
+    return (entry != NULL);
 }
 
 /* Store DATA into CACHE indexed by PATH. On success, returns 0. On failure,
-   returns negative errno value. */
+    returns negative errno value. */
 int
 cache_store(cache_t *cache, char *path, uint8_t *data, size_t size)
 {
-   /* Check size constraint. */
-   if (size > cache->max_item_size) {
-      return -E2BIG;
-   }
+    /* Check size constraint. */
+    if (size > cache->max_item_size) {
+        return -E2BIG;
+    }
 
-   /* Acquire an entry. */
-   size_t n = atomic_fetch_add(&cache->n_ht_entries, 1);
-   if (n >= cache->max_ht_entries) {
-      return -ENOMEM;
-   }
-   hash_entry_t *entry = &cache->ht_entries[n];
+    /* Acquire an entry. */
+    size_t n = atomic_fetch_add(&cache->n_ht_entries, 1);
+    if (n >= cache->max_ht_entries) {
+        return -ENOMEM;
+    }
+    hash_entry_t *entry = &cache->ht_entries[n];
 
-   /* Copy the path into the entry. */
-   strncpy(entry->path, path, MAX_PATH_LENGTH);
+    /* Figure out where the data goes. */
+    entry->size = size;
+    size_t used = atomic_fetch_add(&cache->used, size);
+    entry->ptr = cache->data + used;
 
-   /* Figure out where the data goes. */
-   entry->size = size;
-   size_t used = atomic_fetch_add(&cache->used, size);
-   entry->ptr = cache->data + used;
+    /* Check that this data is being placed in-range before continuing. If we're
+        out-of-range, undo the expansion and abort. */
+    if (used + size > cache->size) {
+        atomic_fetch_sub(&cache->used, size);
+        return -ENOMEM;
+    }
 
-   /* Check that this data is being placed in-range before continuing. If we're
-      out-of-range, undo the expansion and abort. */
-   if (used + size > cache->size) {
-      atomic_fetch_sub(&cache->used, size);
-      return -ENOMEM;
-   }
+    /* Copy the path into the entry. */
+    strncpy(entry->path, path, MAX_PATH_LENGTH);
 
-   /* Copy data to the cache. */
-   memcpy(entry->ptr, data, size);
+    /* Allocate SIZE bytes for this entry's data. */
+    entry->shm_fd = shm_open(entry->path, O_RDWR | O_CREAT, S_IRUSR | S_IWUSR);
+    if (entry->shm_fd < 0) {
+        fprintf(stderr, "failed to shm_open %s\n", entry->path);
+        return -errno;
+    }
 
-   /* Insert into hash table. */
-   pthread_spin_lock(&cache->ht_lock);
-   HASH_ADD_STR(cache->ht, path, entry);
-   pthread_spin_unlock(&cache->ht_lock);
+    /* Copy data to the cache. */
+    memcpy(entry->ptr, data, size);
 
-   return 0;
+    /* Insert into hash table. */
+    pthread_spin_lock(&cache->ht_lock);
+    HASH_ADD_STR(cache->ht, path, entry);
+    pthread_spin_unlock(&cache->ht_lock);
+
+    return 0;
 }
 
 /* Load the data at PATH in CACHE into DATA (a maximum of MAX bytes), storing
-   the size of the file into SIZE. A cache miss is considered a failure
-   (-ENODATA is returned without any IO being issued). On success returns 0.
-   On failure returns negative errno. */
+    the size of the file into SIZE. A cache miss is considered a failure
+    (-ENODATA is returned without any IO being issued). On success returns 0.
+    On failure returns negative errno. */
 int
 cache_load(cache_t *cache, char *path, uint8_t *data, size_t *size, size_t max)
 {
-   hash_entry_t *entry = NULL;
-   HASH_FIND_STR(cache->ht, path, entry);
-   if (entry == NULL) {
-      return -ENODATA;
-   }
+    hash_entry_t *entry = NULL;
+    HASH_FIND_STR(cache->ht, path, entry);
+    if (entry == NULL) {
+        return -ENODATA;
+    }
 
-   /* Don't overflow the buffer. */
-   *size = entry->size;
-   if (entry->size > max) {
-      return -EINVAL;
-   }
-   memcpy(data, entry->ptr, entry->size);
+    /* Don't overflow the buffer. */
+    *size = entry->size;
+    if (entry->size > max) {
+        return -EINVAL;
+    }
+    memcpy(data, entry->ptr, entry->size);
 
-   return 0;
+    return 0;
 }
 
 /* Read an item from CACHE into DATA, indexed by PATH, and located on the
-   filesystem at PATH. On failure returns errno code with negative value,
-   otherwise returns bytes read on success.
-   
-   DATA must be block-aligned, in order for direct IO to work properly.
-   
-   Note we use atomics to implement thread safe options because pthreads and
-   traditional synchronization primitives are not safe to use with the Python
-   interpreter, and may cause deadlock to occur, regardless of the correctness
-   of primitives' usage.
-   
-   It should be noted that the cache is only thread/process safe so long as the
-   cache entries are only written once (as is the case with MinIO). */
+    filesystem at PATH. On failure returns errno code with negative value,
+    otherwise returns bytes read on success.
+    
+    DATA must be block-aligned, in order for direct IO to work properly.
+    
+    Note we use atomics to implement thread safe options because pthreads and
+    traditional synchronization primitives are not safe to use with the Python
+    interpreter, and may cause deadlock to occur, regardless of the correctness
+    of primitives' usage.
+    
+    It should be noted that the cache is only thread/process safe so long as the
+    cache entries are only written once (as is the case with MinIO). */
 ssize_t
 cache_read(cache_t *cache, char *path, void *data, uint64_t max_size)
 {
-   size_t n_accs = STAT_INC(cache, n_accs);
-   if (n_accs % 2500 == 0) {
-      DEBUG_LOG("[MinIO debug] accesses = %lu, hits = %lu, cold misses = %lu, capacity misses = %lu, fails = %lu (usage = %lu/%lu MB) (cache->data = %p) (&cache->used = %p) (pid = %d, ppid = %d)\n", cache->n_accs, cache->n_hits, cache->n_miss_cold, cache->n_miss_capacity, cache->n_fail, cache->used / (1024 * 1024), cache->size / (1024 * 1024), cache->data, &cache->used, getpid(), getppid());
-   }
+    size_t n_accs = STAT_INC(cache, n_accs);
+    if (n_accs % 2500 == 0) {
+        DEBUG_LOG("[MinIO debug] accesses = %lu, hits = %lu, cold misses = %lu, capacity misses = %lu, fails = %lu (usage = %lu/%lu MB) (cache->data = %p) (&cache->used = %p) (pid = %d, ppid = %d)\n", cache->n_accs, cache->n_hits, cache->n_miss_cold, cache->n_miss_capacity, cache->n_fail, cache->used / (1024 * 1024), cache->size / (1024 * 1024), cache->data, &cache->used, getpid(), getppid());
+    }
 
-   /* Check if the file is cached. */
-   size_t bytes = 0;
-   int status = cache_load(cache, path, data, &bytes, max_size);
-   if (status < 0) {
-      /* Don't fail if the error was the file not being cached. */
-      if (status != -ENODATA) {
-         return (ssize_t) status;
-      }
-   } else {
-      STAT_INC(cache, n_hits);
-      return (ssize_t) bytes;
-   }
+    /* Check if the file is cached. */
+    size_t bytes = 0;
+    int status = cache_load(cache, path, data, &bytes, max_size);
+    if (status < 0) {
+        /* Don't fail if the error was the file not being cached. */
+        if (status != -ENODATA) {
+            return (ssize_t) status;
+        }
+    } else {
+        STAT_INC(cache, n_hits);
+        return (ssize_t) bytes;
+    }
 
-   /* Open the file in DIRECT mode. */
-   int fd = open(path, O_RDONLY | __O_DIRECT);
-   if (fd < 0) {
-      STAT_INC(cache, n_fail);
-      return -ENOENT;
-   }
+    /* Open the file in DIRECT mode. */
+    int fd = open(path, O_RDONLY | __O_DIRECT);
+    if (fd < 0) {
+        STAT_INC(cache, n_fail);
+        return -ENOENT;
+    }
 
-   /* Ensure the size of the file is OK. */
-   size_t size = lseek(fd, 0L, SEEK_END);
-   if (size > max_size || size == 0) {
-      close(fd);
-      STAT_INC(cache, n_fail);
-      return -EINVAL;
-   }
-   lseek(fd, 0L, SEEK_SET);
+    /* Ensure the size of the file is OK. */
+    size_t size = lseek(fd, 0L, SEEK_END);
+    if (size > max_size || size == 0) {
+        close(fd);
+        STAT_INC(cache, n_fail);
+        return -EINVAL;
+    }
+    lseek(fd, 0L, SEEK_SET);
 
-   /* Note there is an implicit assumption that two threads/processes will not
-      simultaneously attempt to access the same path for the *first* time.
-      For ML data-loader applications this is satisfied, since each element is
-      accessed only once per epoch, however this will present a race condition
-      in applications where this scenario can occur. */
+    /* Note there is an implicit assumption that two threads/processes will not
+        simultaneously attempt to access the same path for the *first* time.
+        For ML data-loader applications this is satisfied, since each element is
+        accessed only once per epoch, however this will present a race condition
+        in applications where this scenario can occur. */
 
-   /* Read into data. */
-   read(fd, data, (size | 0xFFF) + 1);
-   close(fd);
+    /* Read into data. */
+    read(fd, data, (size | 0xFFF) + 1);
+    close(fd);
 
-   /* Cache the data. If this call fails, the data didn't fit. */
-   if (cache_store(cache, path, data, size) < 0) {
-      STAT_INC(cache, n_miss_capacity);
-   } else {
-      STAT_INC(cache, n_miss_cold);
-   }
+    /* Cache the data. If this call fails, the data didn't fit. */
+    if (cache_store(cache, path, data, size) < 0) {
+        STAT_INC(cache, n_miss_capacity);
+    } else {
+        STAT_INC(cache, n_miss_cold);
+    }
 
-   return size;
+    return size;
 }
 
 /* Clear the cache's hash table and reset used bytes to zero.
 
-   Note this function is NOT thread safe, as safety cannot be ensured by the
-   use of atomics alone, and enforcing safety over the update of all touched
-   fields in read would significantly increase the time the spinlock is held for
-   and thus potentially significantly decrease parallel read performance. */
+    Note this function is NOT thread safe, as safety cannot be ensured by the
+    use of atomics alone, and enforcing safety over the update of all touched
+    fields in read would significantly increase the time the spinlock is held for
+    and thus potentially significantly decrease parallel read performance. */
 void
 cache_flush(cache_t *cache)
 {
-   /* Clear the HT and the cache metadata. */
-   HASH_CLEAR(hh, cache->ht);
-   cache->n_ht_entries = 0;
-   cache->used = 0;
+    /* Clear the HT and the cache metadata. */
+    HASH_CLEAR(hh, cache->ht);
+    cache->n_ht_entries = 0;
+    cache->used = 0;
+
+    /* !!! TODO !!! free all SHM objects and decrease CACHE_SIZE. */
 }
 
 /* Initialize a cache CACHE with SIZE bytes and POLICY replacement policy. On
-   success, 0 is returned. On failure, negative errno value is returned. */
+    success, 0 is returned. On failure, negative errno value is returned. */
 int
 cache_init(cache_t *cache,
-           size_t size,
-           size_t max_item_size,
-           size_t avg_item_size,
-           policy_t policy)
+              size_t size,
+              size_t max_item_size,
+              size_t avg_item_size,
+              policy_t policy)
 {
-   /* Cache configuration. */
-   cache->size = size;
-   cache->used = 0;
-   cache->policy = policy;
-   cache->max_item_size = max_item_size;
+    /* Cache configuration. */
+    cache->size = size;
+    cache->used = 0;
+    cache->policy = policy;
+    cache->max_item_size = max_item_size;
 
-   /* Zero initial stats. */
-   cache->n_accs = 0;
-   cache->n_fail = 0;
-   cache->n_hits = 0;
-   cache->n_miss_capacity = 0;
-   cache->n_miss_cold = 0;
+    /* Zero initial stats. */
+    cache->n_accs = 0;
+    cache->n_fail = 0;
+    cache->n_hits = 0;
+    cache->n_miss_capacity = 0;
+    cache->n_miss_cold = 0;
 
-   /* Initialize the hash table. Allocate more entries than we'll likely need,
-      since file size may vary, and entries are relatively small. */
-   cache->n_ht_entries = 0;
-   if (avg_item_size != 0) {
-      cache->max_ht_entries = (2 * size) / avg_item_size;
-   } else {
-      cache->max_ht_entries = (2 * size) / AVERAGE_FILE_SIZE;
-   }
-   assert(cache->max_ht_entries > 0);
-   cache->ht_size = (cache->max_ht_entries + 1) * sizeof(hash_entry_t);
-   if ((cache->ht_entries = mmap_alloc(cache->ht_size)) == NULL) {
-      return -ENOMEM;
-   }
-   cache->ht = &cache->ht_entries[cache->max_ht_entries];
-   memset(cache->ht_entries, 0, cache->ht_size);
+    /* Initialize the hash table. Allocate more entries than we'll likely need,
+        since file size may vary, and entries are relatively small. */
+    cache->n_ht_entries = 0;
+    if (avg_item_size != 0) {
+        cache->max_ht_entries = (2 * size) / avg_item_size;
+    } else {
+        cache->max_ht_entries = (2 * size) / AVERAGE_FILE_SIZE;
+    }
+    assert(cache->max_ht_entries > 0);
+    cache->ht_size = (cache->max_ht_entries + 1) * sizeof(hash_entry_t);
+    if ((cache->ht_entries = mmap_alloc(cache->ht_size)) == NULL) {
+        return -ENOMEM;
+    }
+    cache->ht = &cache->ht_entries[cache->max_ht_entries];
+    memset(cache->ht_entries, 0, cache->ht_size);
 
-   /* Synchronization initialization. */
-   pthread_spin_init(&cache->ht_lock, PTHREAD_PROCESS_SHARED);
+    /* Synchronization initialization. */
+    pthread_spin_init(&cache->ht_lock, PTHREAD_PROCESS_SHARED);
 
-   /* Get log2 of the number of entries. */
-   int max_ht_entries_copy = cache->max_ht_entries;
-   int max_ht_entries_log2 = 0;
-   while (max_ht_entries_copy >>= 1) max_ht_entries_log2++;
-   HASH_MAKE_TABLE(hh, cache->ht, 0, cache->max_ht_entries, max_ht_entries_log2);
+    /* Get log2 of the number of entries. */
+    int max_ht_entries_copy = cache->max_ht_entries;
+    int max_ht_entries_log2 = 0;
+    while (max_ht_entries_copy >>= 1) max_ht_entries_log2++;
+    HASH_MAKE_TABLE(hh, cache->ht, 0, cache->max_ht_entries, max_ht_entries_log2);
 
-   /* Allocate the cache's memory, and ensure it's 8-byte aligned so that direct
-      IO will work properly. */
-   if ((cache->data = mmap_alloc(cache->size)) == NULL) {
-      mmap_free(cache->ht_entries, cache->ht_size);
-      mmap_free(cache->ht, sizeof(hash_entry_t));
-      return -ENOMEM;
-   }
+    /* We don't allocate the memory used to cache actual data yet. This memory
+        will be allocated on-demand using SHM objects named with the entry's key
+        in the hash table. */
 
-   return 0;
+    return 0;
 }

--- a/csrc/minio/minio.c
+++ b/csrc/minio/minio.c
@@ -125,6 +125,9 @@ cache_store(cache_t *c, char *path, uint8_t *data, size_t size)
         return -ENOMEM;
     }
 
+    /* Page-lock the memory. */
+    mlock(entry->ptr, entry->size);
+
     /* Copy data to the cache. */
     memcpy(entry->ptr, data, size);
 

--- a/csrc/minio/minio.c
+++ b/csrc/minio/minio.c
@@ -147,6 +147,7 @@ cache_load(cache_t *c, char *path, uint8_t *data, size_t *size, size_t max)
     pthread_spin_lock(&c->ht_lock);
     HASH_FIND_STR(c->ht, path, entry);
     if (entry == NULL) {
+        pthread_spin_unlock(&c->ht_lock);
         return -ENODATA;
     }
 

--- a/csrc/minio/minio.c
+++ b/csrc/minio/minio.c
@@ -37,6 +37,8 @@
 #include <unistd.h>
 #include <stdatomic.h>
 #include <pthread.h>
+#include <sys/shm.h>
+#include <sys/mman.h>
 
 #include "../include/uthash.h"
 

--- a/csrc/minio/minio.c
+++ b/csrc/minio/minio.c
@@ -361,6 +361,6 @@ cache_destroy(cache_t *c)
 
     /* Free the spinlocks. */
     if (c->entry_locks != NULL) {
-        munmap(c->entry_locks, sizeof(pthread_spinlock_t) * c->n_entry_locks);
+        munmap((void *) c->entry_locks, sizeof(pthread_spinlock_t) * c->n_entry_locks);
     }
 }

--- a/csrc/minio/minio.h
+++ b/csrc/minio/minio.h
@@ -96,5 +96,6 @@ int cache_load(cache_t *cache, char *path, uint8_t *data, size_t *size, size_t m
 ssize_t cache_read(cache_t *cache, char *filepath, void *data, uint64_t max_size);
 void cache_flush(cache_t *cache);
 int cache_init(cache_t *cache, size_t size, size_t max_item_size, size_t avg_item_size, policy_t policy);
+void cache_destroy(cache_t *c)
 
 #endif

--- a/csrc/minio/minio.h
+++ b/csrc/minio/minio.h
@@ -32,7 +32,7 @@
 #include <pthread.h>
 #include <sys/mman.h>
 
-#define MAX_PATH_LENGTH 128
+#define MAX_PATH_LEN 128
 
 /* Cache replacement policy. */
 typedef enum {
@@ -44,13 +44,15 @@ typedef enum {
 /* Hash table entry. Maps filepath to cached data. An entry must be in the hash
    table IFF the corresponding file is cached. */
 typedef struct {
-    char    path[MAX_PATH_LENGTH + 1];  /* Key. Filepath of file. */
-    void   *ptr;                        /* Pointer to this file's data. */
-    size_t  size;                       /* Size of file data in bytes. */
-    int     shm_fd;                     /* File descriptor for SHM object. */
+    char    path[MAX_PATH_LEN + 1];      /* Key. Filepath of file. */
+    char    shm_path[MAX_PATH_LEN + 2];  /* PATH but with '/' replaced with
+                                               '_' to name the shm object. */
+    void   *ptr;                            /* Pointer to this file's data. */
+    size_t  size;                           /* Size of file data in bytes. */
+    int     shm_fd;                         /* File descriptor for SHM object. */
 
     /* Synchronization. */
-    pthread_spinlock_t lock;            /* Protects entry from eviction. */
+    pthread_spinlock_t lock;                /* Protects entry from eviction. */
 
     UT_hash_handle hh;
 } hash_entry_t;

--- a/csrc/minio/minio.h
+++ b/csrc/minio/minio.h
@@ -49,6 +49,9 @@ typedef struct {
     size_t  size;                       /* Size of file data in bytes. */
     int     shm_fd;                     /* File descriptor for SHM object. */
 
+    /* Synchronization. */
+    pthread_spinlock_t lock;            /* Protects entry from eviction. */
+
     UT_hash_handle hh;
 } hash_entry_t;
 

--- a/csrc/minio/minio.h
+++ b/csrc/minio/minio.h
@@ -47,6 +47,7 @@ typedef struct {
     char    path[MAX_PATH_LENGTH + 1];  /* Key. Filepath of file. */
     void   *ptr;                        /* Pointer to this file's data. */
     size_t  size;                       /* Size of file data in bytes. */
+    int     shm_fd;                     /* File descriptor for SHM object. */
 
     UT_hash_handle hh;
 } hash_entry_t;
@@ -63,11 +64,11 @@ typedef struct {
                                    size of zero indicates there is no limit. */
 
     /* State. */
-    atomic_size_t used;             /* Number of bytes cached. */
-    uint8_t      *data;             /* First byte of SIZE bytes of memory. */
-    hash_entry_t *ht_entries;       /* Memory used for HT entries. */
-    atomic_size_t n_ht_entries;     /* Current number of HT entries. */
-    hash_entry_t *ht;               /* Hash table, maps filename to data. */
+    atomic_size_t  used;            /* Number of bytes cached. */
+    uint8_t       *data;            /* First byte of SIZE bytes of memory. */
+    hash_entry_t  *ht_entries;      /* Memory used for HT entries. */
+    atomic_size_t  n_ht_entries;    /* Current number of HT entries. */
+    hash_entry_t  *ht;              /* Hash table, maps filename to data. */
 
     /* Statistics. */
     atomic_size_t n_accs;

--- a/csrc/minio/minio.h
+++ b/csrc/minio/minio.h
@@ -51,9 +51,6 @@ typedef struct {
     size_t  size;                           /* Size of file data in bytes. */
     int     shm_fd;                         /* File descriptor for SHM object. */
 
-    /* Synchronization. */
-    pthread_spinlock_t lock;                /* Protects entry from eviction. */
-
     UT_hash_handle hh;
 } hash_entry_t;
 

--- a/csrc/minio/minio.h
+++ b/csrc/minio/minio.h
@@ -96,6 +96,6 @@ int cache_load(cache_t *cache, char *path, uint8_t *data, size_t *size, size_t m
 ssize_t cache_read(cache_t *cache, char *filepath, void *data, uint64_t max_size);
 void cache_flush(cache_t *cache);
 int cache_init(cache_t *cache, size_t size, size_t max_item_size, size_t avg_item_size, policy_t policy);
-void cache_destroy(cache_t *c)
+void cache_destroy(cache_t *c);
 
 #endif

--- a/csrc/miniomodule/miniomodule.c
+++ b/csrc/miniomodule/miniomodule.c
@@ -51,23 +51,9 @@ PyCache_dealloc(PyObject *self)
         return;
     }
 
-    /* Only free memory in the cache struct if it's actually been allocated. */
+    /* Destroy the MinIO cache. */
     if (cache->cache != NULL) {
-        /* Free the memory allocated for the hash table. */
-        if (cache->cache->ht_entries != NULL) {
-            munmap(cache->cache->ht_entries,
-                   sizeof(hash_entry_t) * (cache->cache->max_ht_entries + 1));
-        }
-
-        /* Free the memory allocated for spinlocks. */
-        if (cache->cache->entry_locks != NULL) {
-            munmap(cache->cache->entry_locks,
-                   sizeof(pthread_spinlock_t) * cache->cache->n_entry_locks);
-        }
-
-        /* Free each active entry's shm object. (TODO). */
-        
-        /* Free the shared memory allocated for the cache struct. */
+        cache_destroy(cache->cache);
         munmap(cache->cache, sizeof(cache_t));
     }
 

--- a/csrc/miniomodule/miniomodule.c
+++ b/csrc/miniomodule/miniomodule.c
@@ -34,7 +34,6 @@
 /* Python wrapper for cache_t type. */
 typedef struct {
     PyObject_HEAD
-
     cache_t *cache;                     /* MinIO cache. */
     size_t   max_usable_file_size;      /* Max file size we can read. */
     size_t   max_cacheable_file_size;   /* Max file size we can cache. Defaults
@@ -54,16 +53,19 @@ PyCache_dealloc(PyObject *self)
 
     /* Only free memory in the cache struct if it's actually been allocated. */
     if (cache->cache != NULL) {
-        /* Free the shared memory allocated for the cache region. */
-        if (cache->cache->data != NULL) {
-            munmap(cache->cache->data, cache->cache->size);
-        }
-
         /* Free the memory allocated for the hash table. */
         if (cache->cache->ht_entries != NULL) {
             munmap(cache->cache->ht_entries,
                    sizeof(hash_entry_t) * (cache->cache->max_ht_entries + 1));
         }
+
+        /* Free the memory allocated for spinlocks. */
+        if (cache->cache->entry_locks != NULL) {
+            munmap(cache->cache->entry_locks,
+                   sizeof(pthread_spinlock_t) * cache->cache->n_entry_locks);
+        }
+
+        /* Free each active entry's shm object. (TODO). */
         
         /* Free the shared memory allocated for the cache struct. */
         munmap(cache->cache, sizeof(cache_t));

--- a/csrc/utils/utils.c
+++ b/csrc/utils/utils.c
@@ -29,6 +29,14 @@
 
 #define _GNU_SOURCE
 
+/* Simple uint64->uint64 hash function from Stack Overflow, id 12996028. */
+uint64_t
+hash(uint64_t x) {
+    x = (x ^ (x >> 30)) * 0xbf58476d1ce4e5b9ul;
+    x = (x ^ (x >> 27)) * 0x94d049bb133111ebul;
+    x = x ^ (x >> 31);
+    return x;
+}
 
 /* Allocate shared, page-locked memory, using an anonymous mmap. If this process
    forks, and all "shared" state was allocated using this function, everything

--- a/csrc/utils/utils.c
+++ b/csrc/utils/utils.c
@@ -31,7 +31,7 @@
 
 /* Simple uint64->uint64 hash function from Stack Overflow, id 12996028. */
 uint64_t
-hash(uint64_t x) {
+utils_hash(uint64_t x) {
     x = (x ^ (x >> 30)) * 0xbf58476d1ce4e5b9ul;
     x = (x ^ (x >> 27)) * 0x94d049bb133111ebul;
     x = x ^ (x >> 31);

--- a/csrc/utils/utils.h
+++ b/csrc/utils/utils.h
@@ -23,6 +23,7 @@
 
 #ifndef __UTILS_H__
 
+#include <stdint.h>
 #include <stdio.h>
 
 #define DEBUG 0
@@ -35,7 +36,9 @@
     do { if (ALT_DEBUG) fprintf(stderr, "[%8s:%-5d] " fmt, __FILE__, \
                                 __LINE__, ## __VA_ARGS__); } while (0)
 
+#define MAX(a, b) (a) > (b) ? (a) : (b)
 
+uint64_t utils_hash(uint64_t x);
 void *mmap_alloc(size_t size);
 void mmap_free(void *ptr, size_t size);
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(name = 'MinIO Cache',
                           'csrc/utils/utils.c'
                       ],
                       extra_compile_args = [
-                          '-g',
+                          '-lpthread', '-lrt', '-g',
                       ],
                       undef_macros = [
                           "NDEBUG"

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup, Extension
 
 MAJOR = 0
 MINOR = 3
-MICRO = 2
+MICRO = 3
 VERSION = '{}.{}.{}'.format(MAJOR, MINOR, MICRO)
 
 with open('README.md', 'r') as f:

--- a/setup.py
+++ b/setup.py
@@ -19,16 +19,20 @@ setup(name = 'MinIO Cache',
       author_email = 'gus@waldspurger.com',
       license = 'MIT',
       ext_modules = [
-            Extension('minio',
-                      sources = [
-                          'csrc/miniomodule/miniomodule.c',
-                          'csrc/minio/minio.c',
-                          'csrc/utils/utils.c'
-                      ],
-                      extra_compile_args = [
-                          '-lpthread', '-lrt', '-g',
-                      ],
-                      undef_macros = [
-                          "NDEBUG"
-                      ])
+          Extension('minio',
+                    sources = [
+                        'csrc/miniomodule/miniomodule.c',
+                        'csrc/minio/minio.c',
+                        'csrc/utils/utils.c'
+                    ],
+                    extra_link_args = [
+                        '-lpthread',
+                        '-lrt',
+                    ],
+                    extra_compile_args = [
+                        '-g',
+                    ],
+                    undef_macros = [
+                        "NDEBUG"
+                    ])
       ])

--- a/test/c/Makefile
+++ b/test/c/Makefile
@@ -1,7 +1,7 @@
 # https://www.cs.colby.edu/maxwell/courses/tutorials/maketutor/
 
 CC     = gcc
-CFLAGS = -Wall -lpthread -g
+CFLAGS = -Wall -lpthread -lrt -g
 DEPS   = ../../csrc/minio/minio.h ../../csrc/utils/utils.h ../../csrc/utils/uthash.h
 OBJ    = test_minio.o ../../csrc/minio/minio.o ../../csrc/utils/utils.o
 


### PR DESCRIPTION
Instead of allocating all of our memory for the cache up front, use shm to dynamically allocate memory for each file as we need it, keeping tracking of the total usage with an atomic counter. This will also allow for the future addition of other caching policies that include replacement, as we no longer need to worry about external fragmentation between entry's data regions.

We could also do something similar in the future to dynamically allocate new hash table entries, as currently we allocate these up-front, and do not allow growth.